### PR TITLE
拦截刷课时的人机验证请求

### DIFF
--- a/Autovisor.py
+++ b/Autovisor.py
@@ -26,6 +26,7 @@ async def auto_login(page: Page, modules=None):
     if "login" not in page.url:
         logger.info("检测到已登录,跳过登录步骤.")
         return
+    await page.wait_for_selector(".wall-main", state='attached') # 等待登陆界面加载
     if config.username and config.password:
         await page.wait_for_selector("#lUsername", state="attached")
         await page.wait_for_selector("#lPassword", state="attached")

--- a/Autovisor.py
+++ b/Autovisor.py
@@ -4,6 +4,7 @@ import os
 import time
 import traceback
 import sys
+import re
 from playwright.async_api import async_playwright, Playwright, Page, Browser
 from playwright.async_api import TimeoutError
 from playwright._impl._errors import TargetClosedError
@@ -179,6 +180,8 @@ async def main():
         # 先启动人机验证协程
         verify_task = asyncio.create_task(wait_for_verify(page, event_loop_verify))
         await auto_login(page, modules)
+        # 拦截验证码请求
+        await page.route(re.compile(r"^https://.*?\.dun\.163.*?\.com/.*?"), lambda route: route.abort())
         # 启动协程任务
         video_optimize_task = asyncio.create_task(video_optimize(page, config))
         skip_ques_task = asyncio.create_task(skip_questions(page, event_loop_answer))


### PR DESCRIPTION
通过截断网络请求让人机验证不弹出
![屏幕截图 2025-04-01 145020](https://github.com/user-attachments/assets/6b593200-c8d2-46dd-aa70-edc49a0360fe)

在如图所示的课程中测试，刷课一小时未弹出人机验证

修复账号密码为空时跳过登陆的问题 #81 