### PR TITLE
修复：由于工作目录不一致导致无法读取 configs.ini 的 Bug

### DIFF
--- a/Autovisor.py
+++ b/Autovisor.py
@@ -326,7 +326,9 @@ if __name__ == "__main__":
     try:
         print("====== Init Log ======")
         logger.info("程序启动中...")
-        config = Config("configs.ini")
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        config_path = os.path.join(base_dir, "configs.ini")
+        config=Config(config_path)
         if not config.course_urls:
             logger.error("未检测到有效网址或不支持此类网页,请检查配置文件!")
             time.sleep(2)


### PR DESCRIPTION
在 PowerShell 或 Bash 中运行脚本时，如果当前工作目录(CWD)不在项目根目录下，`Autovisor.py` 第 329 行的 
`config = Config("configs.ini")` 会因为相对路径问题无法识别到配置文件。

由于 `configparser` 在找不到文件时会隐式忽略而不抛出 `FileNotFoundError`，导致程序产生有一定误导性的报错：
`configparser.NoSectionError: No section: 'browser-option'`

建议将代码逻辑修改为：
```
base_dir = os.path.dirname(os.path.abspath(__file__))
config_path = os.path.join(base_dir, "configs.ini")
config = Config(config_path)
```
以增强代码的健壮性.