### PR TITLE
修复智慧树新版登录页兼容问题

### DIFF
--- a/Autovisor.py
+++ b/Autovisor.py
@@ -17,6 +17,14 @@ from modules.slider import slider_verify
 from modules.tasks import video_optimize, play_video, skip_questions, wait_for_verify, task_monitor
 from modules import installer
 from modules.banner import print_banner
+from modules.login import (
+    LOGIN_PASSWORD_SELECTOR,
+    LOGIN_SUBMIT_SELECTOR,
+    LOGIN_USERNAME_SELECTOR,
+    accept_login_terms,
+    is_login_page,
+    wait_for_login_complete,
+)
 
 # 获取全局事件循环
 event_loop_verify = asyncio.Event()
@@ -72,43 +80,57 @@ async def init_page(p: Playwright, cookies) -> tuple[Page, BrowserContext]:
     return page, context
 
 async def auto_login(context: BrowserContext, page: Page, modules=None):
-    cookie_saved = False
-
-    async def request_handler(request):
-        nonlocal cookie_saved
-        if cookie_saved:
-            return
-        if "https://www.zhihuishu.com" in request.url:
-            cookies = await context.cookies()
-            save_cookies(cookies, COOKIE_PATH)
-            logger.info(f"已保存登录凭证到: {COOKIE_PATH},下次可免密登录.")
-            cookie_saved = True
-
     await page.goto(config.login_url, wait_until="commit")
-    if "login" not in page.url:
+    if not is_login_page(page.url):
         logger.info("检测到已登录,跳过登录步骤.")
         return
-    await page.wait_for_selector(".wall-main", state='attached')  # 等待登陆界面加载
-    page.on('request', request_handler)
+
     if config.username and config.password:
-        await page.wait_for_selector("#lUsername", state="attached")
-        await page.wait_for_selector("#lPassword", state="attached")
-        await page.locator('#lUsername').fill(config.username)
-        await page.locator('#lPassword').fill(config.password)
-        await page.wait_for_selector(".wall-sub-btn", state="attached")
-        await page.wait_for_timeout(500)
-        await page.locator(".wall-sub-btn").first.click()
+        try:
+            username = await page.wait_for_selector(
+                LOGIN_USERNAME_SELECTOR, state="visible", timeout=30000
+            )
+            password = await page.wait_for_selector(
+                LOGIN_PASSWORD_SELECTOR, state="visible", timeout=30000
+            )
+            await username.fill(config.username)
+            await password.fill(config.password)
+            await accept_login_terms(page)
+            submit = await page.wait_for_selector(
+                LOGIN_SUBMIT_SELECTOR, state="visible", timeout=30000
+            )
+            await page.wait_for_timeout(500)
+            await submit.click()
+        except TimeoutError:
+            if is_login_page(page.url):
+                logger.warn("未找到自动登录控件,请在浏览器中手动完成登录.", shift=True)
+
+    captcha_task = None
     if config.enableAutoCaptcha and modules:
-        await slider_verify(page, modules)
-    await page.wait_for_selector(".wall-main", state='hidden')
+        captcha_task = asyncio.create_task(slider_verify(page, modules))
+
+    try:
+        await wait_for_login_complete(page)
+    finally:
+        if captcha_task:
+            if not captcha_task.done():
+                captcha_task.cancel()
+            await asyncio.gather(captcha_task, return_exceptions=True)
+
+    cookies = await context.cookies()
+    save_cookies(cookies, COOKIE_PATH)
+    logger.info(f"已保存登录凭证到: {COOKIE_PATH},下次可免密登录.")
 
 
 async def ensure_login(context: BrowserContext, page: Page, cookies, modules=None):
     if cookies:
         logger.info("正在校验 Cookies 登录状态...")
         await page.goto(config.login_url, wait_until="domcontentloaded")
-        await page.wait_for_timeout(1500)
-        if "login" not in page.url:
+        try:
+            await wait_for_login_complete(page, timeout=10000)
+        except TimeoutError:
+            pass
+        if not is_login_page(page.url):
             logger.info("使用Cookies登录成功!")
             return True
         logger.warn("检测到 Cookies 已失效, 将重新登录.", shift=True)

--- a/modules/login.py
+++ b/modules/login.py
@@ -1,0 +1,39 @@
+from urllib.parse import urlparse
+
+from playwright.async_api import Page
+
+
+LOGIN_HOSTS = {"login.zhihuishu.com", "passport.zhihuishu.com"}
+LOGIN_USERNAME_SELECTOR = "#lUsername, input[name='mobile']"
+LOGIN_PASSWORD_SELECTOR = "#lPassword, input[type='password']"
+LOGIN_SUBMIT_SELECTOR = ".wall-sub-btn, .btn-block__grandient_login, button[type='submit']"
+
+
+def is_login_page(url: str) -> bool:
+    """判断 URL 是否仍处于智慧树登录流程。"""
+    hostname = (urlparse(url).hostname or "").lower()
+    return hostname in LOGIN_HOSTS
+
+
+async def wait_for_login_complete(
+    page: Page, timeout: float = 24 * 3600 * 1000
+) -> None:
+    """等待页面离开智慧树登录域名。"""
+    if not is_login_page(page.url):
+        return
+    await page.wait_for_url(
+        lambda url: not is_login_page(str(url)),
+        wait_until="commit",
+        timeout=timeout,
+    )
+
+
+async def accept_login_terms(page: Page) -> None:
+    """新版登录页存在协议复选框时自动勾选。"""
+    terms = page.locator(".privacy-checkbox").first
+    if not await terms.count() or not await terms.is_visible():
+        return
+
+    checkbox = terms.locator("input[type='checkbox']").first
+    if await checkbox.count() and not await checkbox.is_checked():
+        await terms.click()

--- a/modules/slider.py
+++ b/modules/slider.py
@@ -96,12 +96,11 @@ async def slider_verify(page: Page, modules: list[ModuleType]):
     isPassed = 0
     for x in range(0, 3):
         try:
-            await page.wait_for_selector(".wall-main", state="attached")
-            await page.wait_for_selector(".yidun_bgimg", state="attached")
+            await page.wait_for_selector(".yidun_bgimg", state="visible")
             logger.info(f"第{x + 1}次尝试过滑块验证...")
             max_loc = await progress_img(page)
             await move_slider(page, max_loc[0])
-            await page.wait_for_selector(".wall-main", state='hidden', timeout=3000)
+            await page.wait_for_selector(".yidun_bgimg", state='hidden', timeout=3000)
             isPassed = 1
             break
         except TimeoutError:

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,0 +1,20 @@
+import unittest
+
+from modules.login import is_login_page
+
+
+class LoginUrlTests(unittest.TestCase):
+    def test_recognizes_current_and_legacy_login_hosts(self):
+        self.assertTrue(is_login_page("https://login.zhihuishu.com/?origin=zhs"))
+        self.assertTrue(is_login_page("https://passport.zhihuishu.com/login"))
+
+    def test_rejects_authenticated_destination_hosts(self):
+        self.assertFalse(is_login_page("https://www.zhihuishu.com/"))
+        self.assertFalse(is_login_page("https://onlineweb.zhihuishu.com/"))
+
+    def test_does_not_match_login_text_outside_the_hostname(self):
+        self.assertFalse(is_login_page("https://example.com/login.zhihuishu.com"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题说明

智慧树登录中心已更换页面结构，旧版代码仍依赖 `.wall-main`、`#lUsername`、`#lPassword` 和 `.wall-sub-btn`。登录发生重定向后，程序继续等待旧页面元素，最终触发 `TargetClosedError`，手动登录也无法继续进入课程。

## 本次改动

- 同时兼容新旧登录页的账号、密码和提交按钮选择器；
- 兼容新版登录页的协议复选框；
- 使用登录域名判断登录流程是否完成，不再依赖旧页面根节点隐藏；
- 登录成功后直接保存当前上下文 Cookies；
- Cookie 校验时等待登录重定向完成，降低误判失效的概率；
- 滑块验证仅依赖验证码自身元素，移除对 `.wall-main` 的依赖；
- 新增登录 URL 判断单元测试。

## 验证情况

- `python -m compileall -q .`
- `python -m unittest discover -s tests -v`
- 当前智慧树登录页在线冒烟测试通过：新账号框、密码框、登录按钮及协议复选框均可识别；
- Windows + Chrome 实际验证通过：自动填写账号、完成滑块验证、保存 Cookies 并进入课程页。

本 PR 不包含配置文件、账号信息、Cookies、日志或构建产物。